### PR TITLE
Added option to specify 'em_corner_radius'.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".MainActivity">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
     <TextView
-            android:id="@+id/tvMenu"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:textStyle="bold"
-            android:textSize="24sp"
-            android:textColor="@android:color/black"
-            android:text="Nothing to show"/>
+        android:id="@+id/tvMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="Nothing to show"
+        android:textColor="@android:color/black"
+        android:textSize="24sp"
+        android:textStyle="bold" />
 
     <pro.midev.expandedmenulibrary.ExpandedMenuView
-            android:id="@+id/expMenu"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:em_background_color="@color/colorPrimary"
-            app:em_shadow_color="@color/colorPrimaryDark"
-            app:em_menu_icon="@drawable/ic_menu"
-            app:em_close_menu_icon="@drawable/ic_close_menu"
-            app:em_text_color="@android:color/white"
-            app:em_outside_margin="24dp"
-            app:em_font_family="rubik_medium.ttf"
-            app:em_is_on_click_closable="false"/>
+        android:id="@+id/expMenu"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:em_background_color="@color/colorPrimary"
+        app:em_close_menu_icon="@drawable/ic_close_menu"
+        app:em_font_family="rubik_medium.ttf"
+        app:em_is_on_click_closable="false"
+        app:em_menu_icon="@drawable/ic_menu"
+        app:em_outside_margin="24dp"
+        app:em_shadow_color="@color/colorPrimaryDark"
+        app:em_text_color="@android:color/white" />
 
 </RelativeLayout>

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -186,9 +186,9 @@ class ExpandedMenuView : View {
             }
             item.setBounds(
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 - menuItemScaleOffset + itemWidth * i).toInt(),
-                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 12.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
+                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 10.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + menuItemScaleOffset + itemWidth * i).toInt(),
-                (measuredHeight - menuOutsideMargin - 24.dpToPx() - 12.dpToPx() + menuItemScaleOffset).toInt()
+                (measuredHeight - menuOutsideMargin - 24.dpToPx() - 10.dpToPx() + menuItemScaleOffset).toInt()
             )
             item.alpha = menuItemAlpha
             item.draw(canvas)
@@ -198,7 +198,7 @@ class ExpandedMenuView : View {
                 menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + itemWidth * i - textPaint.measureText(
                     menuItems[i].name
                 ) / 2,
-                measuredHeight - menuOutsideMargin - 6.dpToPx() - 5f.spToPx(),
+                measuredHeight - menuOutsideMargin - 3.dpToPx() - 5f.spToPx(),
                 textPaint
             )
         }

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -2,19 +2,22 @@ package pro.midev.expandedmenulibrary
 
 import android.animation.Animator
 import android.animation.AnimatorSet
-import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.TypedArray
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
-import android.view.animation.*
+import android.view.animation.AccelerateInterpolator
+import android.view.animation.DecelerateInterpolator
 import kotlin.math.min
 
 class ExpandedMenuView : View {
@@ -40,41 +43,63 @@ class ExpandedMenuView : View {
     private var menuItemScaleOffset: Float = 0f
     private var menuTextAlpha: Int = 0
 
-    var menuOutsideMargin : Float = 24f
+    var menuOutsideMargin: Float = 24f
+    var menuCornerRadius: Float = 18.dpToPx()
     var menuBackground: Int = android.R.color.white
     var shadowColor: Int = android.R.color.black
     var textColor: Int = android.R.color.black
-    var textFontFamily : String = "sans-serif-medium"
+    var textFontFamily: String = "sans-serif-medium"
     var menuIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_help, null)
     var menuCloseIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_revert, null)
     private var menuItems: MutableList<ExpandedMenuItem> = mutableListOf()
-    var isOnClickClosable : Boolean = false
+    var isOnClickClosable: Boolean = false
 
-    private var onItemClickListener : ExpandedMenuClickListener? = null
+    private var onItemClickListener: ExpandedMenuClickListener? = null
 
     constructor(context: Context) : this(context, null)
 
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        val attributes = context.theme.obtainStyledAttributes(attrs, R.styleable.ExpandedMenuView, defStyleAttr, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    ) {
+        val attributes = context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.ExpandedMenuView,
+            defStyleAttr,
+            0
+        )
         initByAttributes(attributes)
         attributes.recycle()
     }
 
     private fun initByAttributes(attributes: TypedArray) {
-        menuOutsideMargin = attributes.getDimensionPixelOffset(R.styleable.ExpandedMenuView_em_outside_margin, menuOutsideMargin.toInt()).toFloat()
-        menuBackground = attributes.getColor(R.styleable.ExpandedMenuView_em_background_color, menuBackground)
+        menuOutsideMargin = attributes.getDimensionPixelOffset(
+            R.styleable.ExpandedMenuView_em_outside_margin,
+            menuOutsideMargin.toInt()
+        ).toFloat()
+        menuCornerRadius = attributes.getDimensionPixelOffset(
+            R.styleable.ExpandedMenuView_em_corner_radius,
+            menuCornerRadius.toInt()
+        ).toFloat()
+        menuBackground =
+            attributes.getColor(R.styleable.ExpandedMenuView_em_background_color, menuBackground)
         shadowColor = attributes.getColor(R.styleable.ExpandedMenuView_em_shadow_color, shadowColor)
         textColor = attributes.getColor(R.styleable.ExpandedMenuView_em_text_color, textColor)
-        textFontFamily = attributes.getString(R.styleable.ExpandedMenuView_em_font_family) ?: textFontFamily
+        textFontFamily =
+            attributes.getString(R.styleable.ExpandedMenuView_em_font_family) ?: textFontFamily
         val iconMenu = attributes.getDrawable(R.styleable.ExpandedMenuView_em_menu_icon)
         if (iconMenu != null) menuIcon = iconMenu
         menuIcon.mutate()
         val iconCloseMenu = attributes.getDrawable(R.styleable.ExpandedMenuView_em_close_menu_icon)
         if (iconCloseMenu != null) menuCloseIcon = iconCloseMenu
         menuCloseIcon.mutate()
-        isOnClickClosable = attributes.getBoolean(R.styleable.ExpandedMenuView_em_is_on_click_closable, isOnClickClosable)
+        isOnClickClosable = attributes.getBoolean(
+            R.styleable.ExpandedMenuView_em_is_on_click_closable,
+            isOnClickClosable
+        )
     }
 
     override fun invalidate() {
@@ -127,7 +152,8 @@ class ExpandedMenuView : View {
         initPainters()
 
         if (currentState == OPEN_STATE) {
-            menuWidthOffset = (measuredWidth - MENU_CLOSE_WIDTH_AND_HEIGHT - menuOutsideMargin * 2).toInt()
+            menuWidthOffset =
+                (measuredWidth - MENU_CLOSE_WIDTH_AND_HEIGHT - menuOutsideMargin * 2).toInt()
         }
         menuRect.set(
             measuredWidth - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT - menuWidthOffset,
@@ -135,7 +161,7 @@ class ExpandedMenuView : View {
             measuredWidth - menuOutsideMargin,
             measuredHeight - menuOutsideMargin
         )
-        canvas.drawRoundRect(menuRect, 18.dpToPx(), 18.dpToPx(), menuPaint)
+        canvas.drawRoundRect(menuRect, menuCornerRadius, menuCornerRadius, menuPaint)
 
         menuIcon.setBounds(
             (measuredWidth - menuOutsideMargin - 40.dpToPx()).toInt(),
@@ -155,7 +181,8 @@ class ExpandedMenuView : View {
         menuCloseIcon.alpha = menuCloseIconAlpha
         menuCloseIcon.draw(canvas)
 
-        val itemWidth: Float = (measuredWidth - menuOutsideMargin * 2 - 8.dpToPx() * (menuItems.size + 2)) / (menuItems.size + 1)
+        val itemWidth: Float =
+            (measuredWidth - menuOutsideMargin * 2 - 8.dpToPx() * (menuItems.size + 2)) / (menuItems.size + 1)
 
         for (i in 0 until menuItems.size) {
             val item = resources.getDrawable(menuItems[i].icon, null)
@@ -166,7 +193,7 @@ class ExpandedMenuView : View {
             }
             item.setBounds(
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 - menuItemScaleOffset + itemWidth * i).toInt(),
-                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 8.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
+                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 12.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + menuItemScaleOffset + itemWidth * i).toInt(),
                 (measuredHeight - menuOutsideMargin - 24.dpToPx() - 12.dpToPx() + menuItemScaleOffset).toInt()
             )
@@ -175,14 +202,21 @@ class ExpandedMenuView : View {
 
             canvas.drawText(
                 menuItems[i].name,
-                menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + itemWidth * i - textPaint.measureText(menuItems[i].name) / 2,
+                menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + itemWidth * i - textPaint.measureText(
+                    menuItems[i].name
+                ) / 2,
                 measuredHeight - menuOutsideMargin - 6.dpToPx() - 5f.spToPx(),
                 textPaint
             )
         }
     }
 
-    fun setIcons(first: ExpandedMenuItem, second: ExpandedMenuItem, third: ExpandedMenuItem, fourth: ExpandedMenuItem? = null) {
+    fun setIcons(
+        first: ExpandedMenuItem,
+        second: ExpandedMenuItem,
+        third: ExpandedMenuItem,
+        fourth: ExpandedMenuItem? = null
+    ) {
         menuItems.clear()
         menuItems.add(first)
         menuItems.add(second)
@@ -192,17 +226,19 @@ class ExpandedMenuView : View {
         }
     }
 
-    fun setOnItemClickListener(listener : ExpandedMenuClickListener) {
+    fun setOnItemClickListener(listener: ExpandedMenuClickListener) {
         this.onItemClickListener = listener
     }
 
+
+    @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent?): Boolean {
         if (event != null && canTouchThis) {
             val x = event.x
             val y = event.y
 
             val closeAndOpenMenuPlace = RectF()
-            val itemsSetList : MutableList<RectF> = mutableListOf()
+            val itemsSetList: MutableList<RectF> = mutableListOf()
 
             when (currentState) {
                 CLOSE_STATE -> {
@@ -221,7 +257,8 @@ class ExpandedMenuView : View {
                         measuredHeight - menuOutsideMargin
                     )
 
-                    val itemWidth: Float = (measuredWidth - menuOutsideMargin * 2 - 8.dpToPx() * (menuItems.size + 2)) / (menuItems.size + 1)
+                    val itemWidth: Float =
+                        (measuredWidth - menuOutsideMargin * 2 - 8.dpToPx() * (menuItems.size + 2)) / (menuItems.size + 1)
 
                     for (i in 0 until menuItems.size) {
                         itemsSetList.add(RectF().apply {
@@ -246,7 +283,8 @@ class ExpandedMenuView : View {
                     for (i in 0 until itemsSetList.size) {
                         if (itemsSetList[i].contains(x, y)) {
                             onItemClickListener?.onItemClick(i)
-                            if (isOnClickClosable) ExpandedMenuAnimation().getCurrentAnimatorSet().start()
+                            if (isOnClickClosable) ExpandedMenuAnimation().getCurrentAnimatorSet()
+                                .start()
                             return true
                         }
                     }

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -157,7 +157,9 @@ class ExpandedMenuView : View {
 
         for (i in 0 until menuItems.size) {
             val item = resources.getDrawable(menuItems[i].icon, null)
+
             menuItems[i].iconTint?.let {
+                item.mutate()
                 item.setTint(it)
             }
             item.setBounds(

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -6,10 +6,7 @@ import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.TypedArray
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.RectF
-import android.graphics.Typeface
+import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
@@ -22,11 +19,6 @@ import kotlin.math.min
 
 class ExpandedMenuView : View {
 
-    private val MENU_CLOSE_WIDTH_AND_HEIGHT = 56.dpToPx()
-
-    private val CLOSE_STATE = 0
-    private val OPEN_STATE = 1
-    private val DRAGGLING = 2
     var currentState = CLOSE_STATE
     private var lastState = CLOSE_STATE
 
@@ -43,16 +35,17 @@ class ExpandedMenuView : View {
     private var menuItemScaleOffset: Float = 0f
     private var menuTextAlpha: Int = 0
 
-    var menuOutsideMargin: Float = 24f
-    var menuCornerRadius: Float = 18.dpToPx()
-    var menuBackground: Int = android.R.color.white
-    var shadowColor: Int = android.R.color.black
-    var textColor: Int = android.R.color.black
-    var textFontFamily: String = "sans-serif-medium"
-    var menuIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_help, null)
-    var menuCloseIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_revert, null)
+    private var menuOutsideMargin: Float = 24f
+    private var menuCornerRadius: Float = 18.dpToPx()
+    private var menuBackground: Int = Color.WHITE
+    private var shadowColor: Int = Color.BLACK
+    private var textColor: Int = Color.BLACK
+    private var textFontFamily: String = "sans-serif-medium"
+    private var menuIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_help, null)
+    private var menuCloseIcon: Drawable =
+        resources.getDrawable(android.R.drawable.ic_menu_revert, null)
     private var menuItems: MutableList<ExpandedMenuItem> = mutableListOf()
-    var isOnClickClosable: Boolean = false
+    private var isOnClickClosable: Boolean = false
 
     private var onItemClickListener: ExpandedMenuClickListener? = null
 
@@ -318,21 +311,29 @@ class ExpandedMenuView : View {
             menuItemAlpha = state.getInt(INSTANCE_MENU_ITEM_ALPHA)
             menuItemScaleOffset = state.getFloat(INSTANCE_MENU_ITEM_SCALE_OFFSET)
             menuTextAlpha = state.getInt(INSTANCE_MENU_TEXT_ALPHA)
-            super.onRestoreInstanceState(state.getParcelable<Parcelable>(INSTANCE_STATE))
+            super.onRestoreInstanceState(state.getParcelable(INSTANCE_STATE))
             return
         }
         super.onRestoreInstanceState(state)
     }
 
     companion object {
-        private val INSTANCE_STATE = "saved_instance"
-        private val INSTANCE_MENU_STATE = "menu_state"
-        private val INSTANCE_MENU_ICON_ALPHA = "menu_icon_alpha"
-        private val INSTANCE_MENU_CLOSE_ICON_ALPHA = "menu_close_icon_alpha"
-        private val INSTANCE_MENU_CAN_TOUCH_THIS = "menu_can_touch_this"
-        private val INSTANCE_MENU_ITEM_ALPHA = "menu_item_alpha"
-        private val INSTANCE_MENU_ITEM_SCALE_OFFSET = "menu_item_scale_offset"
-        private val INSTANCE_MENU_TEXT_ALPHA = "menu_text_alpha"
+
+        private val MENU_CLOSE_WIDTH_AND_HEIGHT = 56.dpToPx()
+
+        private const val CLOSE_STATE = 0
+        private const val OPEN_STATE = 1
+        private const val DRAGGLING = 2
+
+
+        private const val INSTANCE_STATE = "saved_instance"
+        private const val INSTANCE_MENU_STATE = "menu_state"
+        private const val INSTANCE_MENU_ICON_ALPHA = "menu_icon_alpha"
+        private const val INSTANCE_MENU_CLOSE_ICON_ALPHA = "menu_close_icon_alpha"
+        private const val INSTANCE_MENU_CAN_TOUCH_THIS = "menu_can_touch_this"
+        private const val INSTANCE_MENU_ITEM_ALPHA = "menu_item_alpha"
+        private const val INSTANCE_MENU_ITEM_SCALE_OFFSET = "menu_item_scale_offset"
+        private const val INSTANCE_MENU_TEXT_ALPHA = "menu_text_alpha"
     }
 
     inner class ExpandedMenuAnimation {

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -186,9 +186,9 @@ class ExpandedMenuView : View {
             }
             item.setBounds(
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 - menuItemScaleOffset + itemWidth * i).toInt(),
-                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 10.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
+                (measuredHeight - menuOutsideMargin - MENU_CLOSE_WIDTH_AND_HEIGHT + 8.dpToPx() + 12.dpToPx() - menuItemScaleOffset).toInt(),
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + menuItemScaleOffset + itemWidth * i).toInt(),
-                (measuredHeight - menuOutsideMargin - 24.dpToPx() - 10.dpToPx() + menuItemScaleOffset).toInt()
+                (measuredHeight - menuOutsideMargin - 24.dpToPx() - 12.dpToPx() + menuItemScaleOffset).toInt()
             )
             item.alpha = menuItemAlpha
             item.draw(canvas)
@@ -198,7 +198,7 @@ class ExpandedMenuView : View {
                 menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 + itemWidth * i - textPaint.measureText(
                     menuItems[i].name
                 ) / 2,
-                measuredHeight - menuOutsideMargin - 3.dpToPx() - 5f.spToPx(),
+                measuredHeight - menuOutsideMargin - 6.dpToPx() - 5f.spToPx(),
                 textPaint
             )
         }

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -70,8 +70,10 @@ class ExpandedMenuView : View {
         textFontFamily = attributes.getString(R.styleable.ExpandedMenuView_em_font_family) ?: textFontFamily
         val iconMenu = attributes.getDrawable(R.styleable.ExpandedMenuView_em_menu_icon)
         if (iconMenu != null) menuIcon = iconMenu
+        menuIcon.mutate()
         val iconCloseMenu = attributes.getDrawable(R.styleable.ExpandedMenuView_em_close_menu_icon)
         if (iconCloseMenu != null) menuCloseIcon = iconCloseMenu
+        menuCloseIcon.mutate()
         isOnClickClosable = attributes.getBoolean(R.styleable.ExpandedMenuView_em_is_on_click_closable, isOnClickClosable)
     }
 

--- a/expandedmenulibrary/src/main/res/values/attrs.xml
+++ b/expandedmenulibrary/src/main/res/values/attrs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<declare-styleable name="ExpandedMenuView">
+		<attr name="em_corner_radius" format="dimension"/>
 		<attr name="em_outside_margin" format="dimension"/>
 		<attr name="em_background_color" format="color"/>
 		<attr name="em_shadow_color" format="color"/>


### PR DESCRIPTION
1- `em_corner_radius="8dp"`
![Screenshot_20200726-130346](https://user-images.githubusercontent.com/9846942/88508228-b80db800-cff7-11ea-929e-e0b9b13d69f3.png)

`//A hack to get it to show like a normal FAB is to specify a larger radius.`
2- `em_corner_radius="100dp"`
![Screenshot_20200726-130324](https://user-images.githubusercontent.com/9846942/88508318-eee3ce00-cff7-11ea-9bc4-00ca81601c2e.png)

//Default corner radius.
3- `em_corner_radius="18dp"`
![Screenshot_20200726-130434](https://user-images.githubusercontent.com/9846942/88508357-0a4ed900-cff8-11ea-903a-2a18817f210a.png)


Other changes:
Mutate icon/close/item drawable.