### PR TITLE
Brought down the minimum sdk to 14

### DIFF
--- a/expandedmenulibrary/build.gradle
+++ b/expandedmenulibrary/build.gradle
@@ -7,7 +7,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 14
         targetSdkVersion 28
         versionCode 5
         versionName "1.0.5"

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -226,6 +226,13 @@ class ExpandedMenuView : View {
         this.onItemClickListener = listener
     }
 
+    public fun expandMenu() {
+        if(currentState == CLOSE_STATE) ExpandedMenuAnimation().getCurrentAnimatorSet().start()
+    }
+
+    public fun collapseMenu() {
+        if(currentState == OPEN_STATE) ExpandedMenuAnimation().getCurrentAnimatorSet().start()
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent?): Boolean {

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.drawable.DrawableCompat
+import android.text.TextUtils.isEmpty
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -42,7 +43,7 @@ class ExpandedMenuView : View {
     private var menuBackground: Int = Color.WHITE
     private var shadowColor: Int = Color.BLACK
     private var textColor: Int = Color.BLACK
-    private var textFontFamily: String = "sans-serif-medium"
+    private var textFontFamily: String = ""
     private var menuIcon: Drawable = ContextCompat.getDrawable(context, android.R.drawable.ic_menu_help)!!
     private var menuCloseIcon: Drawable =
         ContextCompat.getDrawable(context, android.R.drawable.ic_menu_revert)!!
@@ -116,9 +117,9 @@ class ExpandedMenuView : View {
             textSize = 10f.spToPx()
             isAntiAlias = true
             style = Paint.Style.FILL
-            typeface = Typeface.createFromAsset(context.assets, textFontFamily)
             alpha = menuTextAlpha
         }
+        if(!isEmpty(textFontFamily)) textPaint.typeface = Typeface.createFromAsset(context.assets, textFontFamily)
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
+++ b/expandedmenulibrary/src/main/java/pro/midev/expandedmenulibrary/ExpandedMenuView.kt
@@ -10,6 +10,8 @@ import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
+import android.support.v4.content.ContextCompat
+import android.support.v4.graphics.drawable.DrawableCompat
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -41,9 +43,9 @@ class ExpandedMenuView : View {
     private var shadowColor: Int = Color.BLACK
     private var textColor: Int = Color.BLACK
     private var textFontFamily: String = "sans-serif-medium"
-    private var menuIcon: Drawable = resources.getDrawable(android.R.drawable.ic_menu_help, null)
+    private var menuIcon: Drawable = ContextCompat.getDrawable(context, android.R.drawable.ic_menu_help)!!
     private var menuCloseIcon: Drawable =
-        resources.getDrawable(android.R.drawable.ic_menu_revert, null)
+        ContextCompat.getDrawable(context, android.R.drawable.ic_menu_revert)!!
     private var menuItems: MutableList<ExpandedMenuItem> = mutableListOf()
     private var isOnClickClosable: Boolean = false
 
@@ -178,11 +180,11 @@ class ExpandedMenuView : View {
             (measuredWidth - menuOutsideMargin * 2 - 8.dpToPx() * (menuItems.size + 2)) / (menuItems.size + 1)
 
         for (i in 0 until menuItems.size) {
-            val item = resources.getDrawable(menuItems[i].icon, null)
+            val item = ContextCompat.getDrawable(context, menuItems[i].icon)!!
 
             menuItems[i].iconTint?.let {
                 item.mutate()
-                item.setTint(it)
+                DrawableCompat.setTint(item, it)
             }
             item.setBounds(
                 (menuOutsideMargin + 8.dpToPx() * (i + 1) + itemWidth / 2 - menuItemScaleOffset + itemWidth * i).toInt(),


### PR DESCRIPTION
As the title says, minimum sdk was around 21 which is way higher for opensource apps on F-droid. I have two apps on F-droid in one of them, I want to use this component hence tried to see why is minimum sdk around 21.

Font face was kind of mandatory in library. If not provided, app was crashing. I am not using any fonts in my app and am living with default fonts from the device. Hence removed the compulsion of providing fontface.

Also added programatically open and close menu functionality